### PR TITLE
fix: size snap.jpg from the requested width, and give the inline LOCAL snap a workable budget (#55)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ Full release history for the Bosch Smart Home Camera HA integration.
 Newest first. The README only highlights the most recent release — for older
 versions see this file or the [GitHub Releases page](https://github.com/mosandlt/Bosch-Smart-Home-Camera-Tool-HomeAssistant/releases) (each release page mirrors the same notes plus downloadable assets).
 
+## [Unreleased]
+
+### Fixed
+
+- **Card snapshots could freeze permanently on a Gen1 camera with an active LOCAL session** (GitHub [#55](https://github.com/mosandlt/Bosch-Smart-Home-Camera-Tool-HomeAssistant/issues/55), realKim-dotcom — measured on the same constrained-link Gen1 testbed as #54). Two independent causes, both in the snapshot path:
+  - **`snap.jpg` was always requested at full resolution.** Every call site hardcoded `JpegSize=1206` (~500 KB measured) even though the Lovelace card asks HA for `width=315`. On a constrained link the body alone can outlast HA's 10 s `CAMERA_IMAGE_TIMEOUT`, so the preview fetch fails and the card keeps showing whatever was cached. The requested size is now derived from the width HA passes to `async_camera_image()` (new `jpeg_size_for_width()`/`with_jpeg_size()` in `const.py`): ~65 KB at `JpegSize=320` for a card-sized request, ~220 KB at 640. Callers that persist or analyse the frame — the background image refresh, the `image.*` entity, AI analysis — pass no width and keep full resolution, byte-for-byte the same URL as before.
+  - **The inline LOCAL snap budget sat below what these cameras cost from cold.** `_async_camera_image_impl`'s tier-1 Digest fetch ran under `asyncio.timeout(6)`, chosen to avoid a `12 s + 10 s` cascade — but the LOCAL branch returns immediately after that attempt and deliberately skips the aiohttp fallback beneath it, so no cascade exists there and the only ceiling is HA's 10 s. Measured cold cost on Gen1: TLS handshake alone 2.5–6.9 s, ~7.05 s end to end; warm on a pooled connection, 0.05–0.79 s. A budget above the warm cost but below the cold cost can never succeed from cold, and since a handshake killed by the timeout is never pooled, cold is the only state such a camera reaches — so it failed 100 % of the time rather than occasionally. Now `LOCAL_SNAP_TIMEOUT` (8.5 s), leaving ~1.5 s of margin under HA's ceiling.
+  - Reported symptom before the fix, on a camera whose Mini-NVR was in `continuous` mode (no pre-roll ring to cover for the snapshot path): 6.0 s on every request and a byte-identical JPEG each time — a permanently frozen preview. After: 7.05 s cold, then 0.61–0.79 s pooled, with different content each request; a frame fetched at 18:23:38 carried a burnt-in OSD of 18:23:37.
+
 ## [v16.1.2] - 2026-07-17
 
 Patch — bundles fixes shipped across beta iterations (beta-1/beta-2/beta-3/beta-4/beta-5/beta-6/beta-7/beta-8/beta-9/beta-10/beta-11/beta-12) before going stable. No breaking changes.

--- a/custom_components/bosch_shc_camera/camera.py
+++ b/custom_components/bosch_shc_camera/camera.py
@@ -53,9 +53,13 @@ from .cloud_ssl import async_get_bosch_cloud_session
 from .const import (
     AUTO_PLAY_DEFAULT_VALUES,
     DOMAIN,
+    JPEG_SIZE_FULL,
+    JPEG_SIZE_MEDIUM,
     LIVE_SESSION_TTL,
     STREAM_START_SKIPPED,
     TIMEOUT_SNAP,
+    jpeg_size_for_width,
+    with_jpeg_size,
 )
 from .mjpeg_snapshot import fetch_mjpeg_snapshot
 from .models import (
@@ -80,13 +84,30 @@ IDLE_FRAME_INTERVAL = (
     60  # seconds — how often HA's camera proxy calls async_camera_image
 )
 
+# Budget for the inline LOCAL Digest snap.jpg in tier 1 (see call site). This
+# branch returns immediately after the attempt — it deliberately skips the
+# aiohttp fallback below it, because a LOCAL proxyUrl needs the Digest auth
+# that was just tried — so the only ceiling that applies is HA's
+# CAMERA_IMAGE_TIMEOUT (10 s). 8.5 s keeps ~1.5 s of margin under it.
+#
+# It used to be a bare 6 s, which is *below* what a Gen1 camera costs from
+# cold: the TLS handshake alone measures 2.5-6.9 s (the TCP connect under it is
+# 10-500 ms), and a cold snap.jpg round-trip measured 7.05 s end to end. A
+# budget above the warm cost but below the cold cost can never succeed from
+# cold — and since a handshake killed by the timeout is never pooled, cold is
+# the only state such a camera ever reaches, so it failed 100% of the time
+# rather than occasionally. Warm, over a pooled connection, the same fetch
+# takes 0.05-0.79 s.
+LOCAL_SNAP_TIMEOUT = 8.5
+
 # Worst-case cumulative time budget of the 5-tier snapshot fallback cascade in
 # _async_camera_image_impl, if every tier is attempted and every tier times
-# out: tier1 LOCAL live-proxy snap (6s) OR REMOTE live-proxy snap + one renew
-# retry (10s + 10s), tier2b LOCAL outage snap.jpg (12s), tier4 latest-event
-# snapshot (10s, capped from 20s — see call site). Logged at DEBUG for
-# visibility into how long a single async_camera_image() call can bind the
-# event loop before falling back to the cached image/placeholder.
+# out: tier1 LOCAL live-proxy snap (LOCAL_SNAP_TIMEOUT, which returns straight
+# away) OR REMOTE live-proxy snap + one renew retry (10s + 10s), tier2b LOCAL
+# outage snap.jpg (12s), tier4 latest-event snapshot (10s, capped from 20s —
+# see call site). Logged at DEBUG for visibility into how long a single
+# async_camera_image() call can bind the event loop before falling back to the
+# cached image/placeholder.
 SNAPSHOT_FALLBACK_MAX_BUDGET_SEC = 10 + 10 + 12 + 10
 
 
@@ -1047,7 +1068,13 @@ class BoschCamera(CoordinatorEntity, Camera):  # type: ignore[misc]
         token = self._token
         headers_bearer = {"Authorization": f"Bearer {token}", "Accept": "*/*"}
         # True when card requests a mobile/thumbnail-sized image
-        prefer_small = width is not None and width <= 640
+        prefer_small = width is not None and width <= JPEG_SIZE_MEDIUM
+        # snap.jpg resolution for this request: JPEG_SIZE_THUMB/_MEDIUM for a
+        # card-sized request, None (= keep full resolution) otherwise. Only the
+        # snapshot fetches on this request path get it — the background refresh
+        # and the image.* entity call the coordinator without a width and so
+        # keep JPEG_SIZE_FULL for the persisted snapshot.
+        req_jpeg_size = jpeg_size_for_width(width)
         _LOGGER.debug(
             "%s: snapshot fallback chain start (worst-case budget %ds)",
             self._display_name,
@@ -1100,7 +1127,10 @@ class BoschCamera(CoordinatorEntity, Camera):  # type: ignore[misc]
 
         # ── 1. Cloud proxy live snapshot (active live-stream session) ─────────
         live = self.coordinator.live_connections.get(self._cam_id, {})
-        proxy_url = live.get("proxyUrl", "")
+        # The session's proxyUrl is built once, before any caller's width is
+        # known, so it carries JPEG_SIZE_FULL. Scale it down per request when
+        # the card only needs a thumbnail; unchanged when no width was asked for.
+        proxy_url = with_jpeg_size(live.get("proxyUrl", ""), req_jpeg_size)
         if proxy_url:
             # LOCAL connection: snap.jpg requires HTTP Digest auth
             if live.get("_connection_type") == "LOCAL":
@@ -1123,16 +1153,20 @@ class BoschCamera(CoordinatorEntity, Camera):  # type: ignore[misc]
                 if local_user and local_pass:
                     data: bytes | None = None
                     try:
-                        # Tightened from 12 s to 6 s: HA's CameraImageView wraps
-                        # async_camera_image() with CAMERA_IMAGE_TIMEOUT (10 s);
-                        # 12 s + 10 s aiohttp fallback below = >22 s, well over
-                        # HA's outer timeout. HA cancels mid-flight → image=None
-                        # → HomeAssistantError → 26-byte "500: Internal Server
+                        # LOCAL_SNAP_TIMEOUT, not the 12 s used elsewhere: HA's
+                        # CameraImageView wraps async_camera_image() with
+                        # CAMERA_IMAGE_TIMEOUT (10 s), and overrunning it means
+                        # HA cancels mid-flight → image=None →
+                        # HomeAssistantError → 26-byte "500: Internal Server
                         # Error" body rendered as a brown placeholder on the
-                        # camera card. 6 s is enough for a healthy LAN Digest
-                        # round-trip; if it fails, return cached/placeholder
-                        # immediately rather than racing HA's outer timeout.
-                        async with asyncio.timeout(6):
+                        # camera card. Nothing else runs after this attempt on
+                        # the LOCAL branch (see the comment below the fetch), so
+                        # 8.5 s is the largest budget that still leaves margin
+                        # under HA's ceiling — and a Gen1 camera needs about
+                        # 7 s from cold. If it does fail, return
+                        # cached/placeholder immediately rather than racing HA's
+                        # outer timeout.
+                        async with asyncio.timeout(LOCAL_SNAP_TIMEOUT):
                             async with await async_digest_request(
                                 session,
                                 "GET",
@@ -1232,7 +1266,9 @@ class BoschCamera(CoordinatorEntity, Camera):  # type: ignore[misc]
                             self._display_name,
                         )
                     elif new_live:
-                        new_proxy_url = new_live.get("proxyUrl", "")
+                        new_proxy_url = with_jpeg_size(
+                            new_live.get("proxyUrl", ""), req_jpeg_size
+                        )
                         if new_proxy_url:
                             try:
                                 async with asyncio.timeout(10):
@@ -1310,12 +1346,12 @@ class BoschCamera(CoordinatorEntity, Camera):  # type: ignore[misc]
                         )
                         return rcp_img
                 fresh: bytes | None = await self.coordinator.async_fetch_live_snapshot(
-                    self._cam_id
+                    self._cam_id, jpeg_size=req_jpeg_size
                 )
                 if not fresh:
                     # REMOTE snap.jpg returns 401 on CAMERA_360 — try LOCAL Digest fallback
                     fresh = await self.coordinator.async_fetch_live_snapshot_local(
-                        self._cam_id
+                        self._cam_id, jpeg_size=req_jpeg_size
                     )
                 if fresh:
                     self.cached_image = fresh
@@ -1351,12 +1387,12 @@ class BoschCamera(CoordinatorEntity, Camera):  # type: ignore[misc]
                         self.last_image_fetch = now
                         return rcp_img
                 fresh2: bytes | None = await self.coordinator.async_fetch_live_snapshot(
-                    self._cam_id
+                    self._cam_id, jpeg_size=req_jpeg_size
                 )
                 if not fresh2:
                     # REMOTE snap.jpg returns 401 on CAMERA_360 — try LOCAL Digest fallback
                     fresh2 = await self.coordinator.async_fetch_live_snapshot_local(
-                        self._cam_id
+                        self._cam_id, jpeg_size=req_jpeg_size
                     )
                 if fresh2:
                     self.cached_image = fresh2
@@ -1392,7 +1428,10 @@ class BoschCamera(CoordinatorEntity, Camera):  # type: ignore[misc]
             host = creds.get("host", "")
             port = creds.get("port", 443)
             if local_user and local_pass and host:
-                snap_url = f"https://{host}:{port}/snap.jpg?JpegSize=1206"
+                snap_url = with_jpeg_size(
+                    f"https://{host}:{port}/snap.jpg?JpegSize={JPEG_SIZE_FULL}",
+                    req_jpeg_size,
+                )
                 outage_data: bytes | None = None
                 try:
                     async with asyncio.timeout(12):

--- a/custom_components/bosch_shc_camera/const.py
+++ b/custom_components/bosch_shc_camera/const.py
@@ -1,5 +1,7 @@
 """Constants for the Bosch Smart Home Camera integration."""
 
+import re
+
 DOMAIN = "bosch_shc_camera"
 
 # Lovelace card version — must match CARD_VERSION in src/bosch-camera-card.js.
@@ -79,6 +81,53 @@ class _StreamStartSkipped(dict):  # type: ignore[type-arg]
 
 # Singleton instance — compare with ``is STREAM_START_SKIPPED``.
 STREAM_START_SKIPPED = _StreamStartSkipped()
+
+# ── snap.jpg resolution (`JpegSize`) ──────────────────────────────────────────
+# Every snap.jpg call site used to hardcode JpegSize=1206 (full resolution),
+# including the ones serving the Lovelace card — which asks HA for width=315.
+# Measured payloads for the same frame on one Gen1 outdoor camera:
+#
+#     JpegSize=1206  ≈ 500 KB      JpegSize=640  ≈ 220 KB      JpegSize=320  ≈ 65 KB
+#
+# On a bandwidth-constrained link the full-res body alone can take longer than
+# HA's CAMERA_IMAGE_TIMEOUT (10 s), so a preview request fails outright and the
+# card shows a stale frame. Deriving the size from the width HA passed to
+# async_camera_image() costs nothing for callers that want full resolution:
+# jpeg_size_for_width() returns None (= "leave it at JPEG_SIZE_FULL") whenever
+# no width was requested, which is what the background image refresh, the
+# image.* entity and the AI-analysis fetch do.
+JPEG_SIZE_FULL = 1206
+JPEG_SIZE_THUMB = 320
+JPEG_SIZE_MEDIUM = 640
+
+_JPEG_SIZE_RE = re.compile(r"JpegSize=\d+")
+
+
+def jpeg_size_for_width(width: int | None) -> int | None:
+    """Map the width HA requested onto a camera ``JpegSize`` value.
+
+    Returns ``None`` when the caller did not ask for a thumbnail-sized image,
+    meaning the snap.jpg URL should keep its full-resolution ``JpegSize``.
+    """
+    if width is None or width <= 0 or width > JPEG_SIZE_MEDIUM:
+        return None
+    if width <= JPEG_SIZE_THUMB:
+        return JPEG_SIZE_THUMB
+    return JPEG_SIZE_MEDIUM
+
+
+def with_jpeg_size(url: str, size: int | None) -> str:
+    """Return ``url`` with its ``JpegSize`` query parameter set to ``size``.
+
+    A ``size`` of ``None`` (no width requested) returns the URL unchanged, so
+    full-resolution callers keep exactly the URL they had before.
+    """
+    if not url or not size:
+        return url
+    if "JpegSize=" in url:
+        return _JPEG_SIZE_RE.sub(f"JpegSize={int(size)}", url)
+    return f"{url}{'&' if '?' in url else '?'}JpegSize={int(size)}"
+
 
 # ── Network timeouts (seconds) ────────────────────────────────────────────────
 # Centralised so snap + PUT /connection paths stay consistent across the

--- a/custom_components/bosch_shc_camera/coordinator.py
+++ b/custom_components/bosch_shc_camera/coordinator.py
@@ -44,6 +44,7 @@ from .const import (
     CLOUD_API,
     DEFAULT_OPTIONS,
     DOMAIN,
+    JPEG_SIZE_FULL,
     SHC_MAX_FAILS,
     SHC_RETRY_INTERVAL,
     STREAM_START_SKIPPED,
@@ -3200,12 +3201,20 @@ class BoschCameraCoordinator(
             _LOGGER.debug("NVR cleanup background task error: %s", err)
 
     # ── go2rtc integration ────────────────────────────────────────────────────
-    async def async_fetch_live_snapshot(self, cam_id: str) -> bytes | None:
+    async def async_fetch_live_snapshot(
+        self, cam_id: str, jpeg_size: int | None = None
+    ) -> bytes | None:
         """Open a temporary REMOTE live connection to fetch a fresh snap.jpg.
 
         Does NOT register the connection in live_connections — the live stream
         switch stays OFF. Used by background image refresh so cameras always
         show a current image rather than a (possibly expired) event snapshot.
+
+        ``jpeg_size`` overrides snap.jpg's resolution for callers that only need
+        a preview (see const.jpeg_size_for_width). The default of ``None`` keeps
+        JPEG_SIZE_FULL, so the background refresh, the image.* entity and the
+        AI-analysis fetch — everything that persists or analyses the frame —
+        are unaffected.
 
         Proxy URL caching: PUT /connection takes ~1.5s. The resulting proxy lease
         lasts ~60s. We cache urls[0] for 50s and skip PUT /connection on warm
@@ -3217,10 +3226,14 @@ class BoschCameraCoordinator(
         """
         lock = get_or_create_lock(self._snapshot_fetch_locks, cam_id)
         async with lock:
-            return await self._async_fetch_live_snapshot_impl(cam_id)
+            return await self._async_fetch_live_snapshot_impl(cam_id, jpeg_size)
 
-    async def _async_fetch_live_snapshot_impl(self, cam_id: str) -> bytes | None:
+    async def _async_fetch_live_snapshot_impl(
+        self, cam_id: str, jpeg_size: int | None = None
+    ) -> bytes | None:
         import json as _json
+
+        snap_jpeg_size = jpeg_size or JPEG_SIZE_FULL
 
         token = self.token
         if not token:
@@ -3344,7 +3357,7 @@ class BoschCameraCoordinator(
                             _rcp_err,
                         )
 
-                proxy_url = f"https://{url_entry}/snap.jpg?JpegSize=1206"
+                proxy_url = f"https://{url_entry}/snap.jpg?JpegSize={snap_jpeg_size}"
                 async with asyncio.timeout(TIMEOUT_SNAP):
                     async with session.get(proxy_url) as snap_resp:
                         ct = snap_resp.headers.get("Content-Type", "")
@@ -3358,7 +3371,7 @@ class BoschCameraCoordinator(
                             url_entry2 = await _get_proxy_url_entry()
                             if not url_entry2:
                                 return None
-                            proxy_url2 = f"https://{url_entry2}/snap.jpg?JpegSize=1206"
+                            proxy_url2 = f"https://{url_entry2}/snap.jpg?JpegSize={snap_jpeg_size}"
                             async with asyncio.timeout(TIMEOUT_SNAP):
                                 async with session.get(proxy_url2) as snap_resp2:
                                     ct2 = snap_resp2.headers.get("Content-Type", "")
@@ -3802,7 +3815,9 @@ class BoschCameraCoordinator(
 
             return None
 
-    async def async_fetch_live_snapshot_local(self, cam_id: str) -> bytes | None:
+    async def async_fetch_live_snapshot_local(
+        self, cam_id: str, jpeg_size: int | None = None
+    ) -> bytes | None:
         """Fetch a live snapshot via LOCAL connection using HTTP Digest auth.
 
         For cameras like CAMERA_360 whose REMOTE snap.jpg returns 401,
@@ -3810,6 +3825,9 @@ class BoschCameraCoordinator(
         snap.jpg directly from the camera's LAN IP.
 
         Uses auth_utils.async_digest_request (aiohttp) for non-blocking Digest auth.
+
+        ``jpeg_size`` behaves as in async_fetch_live_snapshot: ``None`` keeps
+        the full-resolution frame the persisting callers expect.
         """
         token = self.token
         if not token:
@@ -3873,7 +3891,9 @@ class BoschCameraCoordinator(
             return None
 
         camera_host = urls[0]  # e.g. "192.168.x.x:443"
-        snap_url = f"https://{camera_host}/snap.jpg?JpegSize=1206"
+        snap_url = (
+            f"https://{camera_host}/snap.jpg?JpegSize={jpeg_size or JPEG_SIZE_FULL}"
+        )
 
         from homeassistant.helpers.aiohttp_client import async_get_clientsession
 

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -36,6 +36,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from custom_components.bosch_shc_camera.const import (
+    JPEG_SIZE_FULL,
+    JPEG_SIZE_MEDIUM,
+    JPEG_SIZE_THUMB,
+)
+
 if TYPE_CHECKING:
     from custom_components.bosch_shc_camera.camera import BoschCamera
 
@@ -4152,7 +4158,7 @@ class TestIdleCameraCloudSnapshot:
 
             out = await BoschCamera._async_camera_image_impl(cam)
 
-        coord.async_fetch_live_snapshot.assert_awaited_once_with(CAM_ID)
+        coord.async_fetch_live_snapshot.assert_awaited_once_with(CAM_ID, jpeg_size=None)
         assert out == b"\xff\xd8snap", (
             "must return snapshot from async_fetch_live_snapshot"
         )
@@ -4195,7 +4201,9 @@ class TestIdleCameraCloudSnapshot:
 
             out = await BoschCamera._async_camera_image_impl(cam, width=320)
 
-        coord.async_fetch_live_snapshot.assert_awaited_once_with(CAM_ID)
+        coord.async_fetch_live_snapshot.assert_awaited_once_with(
+            CAM_ID, jpeg_size=JPEG_SIZE_THUMB
+        )
         assert out == b"\xff\xd8snap", (
             "must fall to async_fetch_live_snapshot when RCP fails"
         )
@@ -4216,7 +4224,9 @@ class TestIdleCameraCloudSnapshot:
 
             out = await BoschCamera._async_camera_image_impl(cam)
 
-        coord.async_fetch_live_snapshot_local.assert_awaited_once_with(CAM_ID)
+        coord.async_fetch_live_snapshot_local.assert_awaited_once_with(
+            CAM_ID, jpeg_size=None
+        )
         assert out == b"\xff\xd8local", (
             "must use LOCAL fallback when REMOTE snap returns None"
         )
@@ -4240,7 +4250,7 @@ class TestIdleCameraCloudSnapshot:
 
             out = await BoschCamera._async_camera_image_impl(cam)
 
-        coord.async_fetch_live_snapshot.assert_awaited_once_with(CAM_ID)
+        coord.async_fetch_live_snapshot.assert_awaited_once_with(CAM_ID, jpeg_size=None)
         assert out == b"\xff\xd8fresh", "must return fresh bytes when cache is stale"
         assert cam.cached_image == b"\xff\xd8fresh", (
             "must update cache with fresh bytes"
@@ -4859,6 +4869,142 @@ class TestLocalSnapViaProxy:
         (
             digest_mock.assert_not_called(),
             "async_digest_request must not be called when no LOCAL creds",
+        )
+
+
+class TestSnapshotJpegSizeFromRequestedWidth:
+    """snap.jpg must be requested at the size the caller actually needs.
+
+    Every call site used to hardcode JpegSize=1206 (~500 KB) even for the
+    Lovelace card, which asks HA for width=315 (~65 KB at JpegSize=320). On a
+    constrained link the full-res body alone can outlast HA's 10 s
+    CAMERA_IMAGE_TIMEOUT, so the preview fails and a stale frame is served.
+    Callers that persist or analyse the frame pass no width and must keep the
+    full-resolution URL byte-for-byte.
+    """
+
+    @staticmethod
+    async def _digest_url_for(width: int | None) -> str:
+        """Run the tier-1 LOCAL snap and return the URL it fetched."""
+        coord = _local_live_conn()
+        cam = _make_camera_r7(coord=coord)
+        digest_mock = AsyncMock(return_value=_digest_cm(200, b"\xff\xd8local"))
+        with (
+            patch(
+                "custom_components.bosch_shc_camera.camera.async_get_bosch_cloud_session",
+                new=AsyncMock(return_value=MagicMock()),
+            ),
+            patch(
+                "custom_components.bosch_shc_camera.camera.async_digest_request",
+                new=digest_mock,
+            ),
+        ):
+            from custom_components.bosch_shc_camera.camera import BoschCamera
+
+            await BoschCamera._async_camera_image_impl(cam, width=width)
+        return str(digest_mock.await_args.args[2])
+
+    @pytest.mark.asyncio
+    async def test_card_width_shrinks_local_snap_to_thumbnail(self):
+        """width=315 (what the card requests) → JpegSize=320, not 1206."""
+        url = await self._digest_url_for(315)
+        assert f"JpegSize={JPEG_SIZE_THUMB}" in url, (
+            "a thumbnail-sized request must not pull the full-res frame"
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_width_leaves_local_snap_url_untouched(self):
+        """No width (persisting/background callers) → URL unchanged."""
+        url = await self._digest_url_for(None)
+        assert url == LOCAL_SNAP_URL, "full-res callers must keep their URL as-is"
+        assert "JpegSize" not in url
+
+    @pytest.mark.parametrize(
+        ("width", "expected"),
+        [
+            (None, None),  # no width requested → keep full resolution
+            (0, None),  # defensive: nonsense width → keep full resolution
+            (-1, None),
+            (315, JPEG_SIZE_THUMB),  # the Lovelace card's actual request
+            (JPEG_SIZE_THUMB, JPEG_SIZE_THUMB),  # boundary
+            (321, JPEG_SIZE_MEDIUM),
+            (JPEG_SIZE_MEDIUM, JPEG_SIZE_MEDIUM),  # boundary
+            (JPEG_SIZE_MEDIUM + 1, None),  # bigger than a preview → full res
+            (1920, None),
+        ],
+    )
+    def test_jpeg_size_for_width_mapping(self, width, expected):
+        """The width → JpegSize mapping, including both boundaries."""
+        from custom_components.bosch_shc_camera.const import jpeg_size_for_width
+
+        assert jpeg_size_for_width(width) == expected
+
+    @pytest.mark.parametrize(
+        ("url", "size", "expected"),
+        [
+            # rewrite an existing parameter
+            (
+                f"https://host/snap.jpg?JpegSize={JPEG_SIZE_FULL}",
+                JPEG_SIZE_THUMB,
+                f"https://host/snap.jpg?JpegSize={JPEG_SIZE_THUMB}",
+            ),
+            # append when the URL has none (LOCAL proxyUrl form)
+            (
+                "https://host/snap.jpg",
+                JPEG_SIZE_THUMB,
+                f"https://host/snap.jpg?JpegSize={JPEG_SIZE_THUMB}",
+            ),
+            # append alongside an unrelated parameter
+            (
+                "https://host/snap.jpg?foo=1",
+                JPEG_SIZE_MEDIUM,
+                f"https://host/snap.jpg?foo=1&JpegSize={JPEG_SIZE_MEDIUM}",
+            ),
+            # size=None → untouched, so full-res callers are byte-identical
+            (
+                f"https://host/snap.jpg?JpegSize={JPEG_SIZE_FULL}",
+                None,
+                f"https://host/snap.jpg?JpegSize={JPEG_SIZE_FULL}",
+            ),
+            ("", JPEG_SIZE_THUMB, ""),
+        ],
+    )
+    def test_with_jpeg_size_rewrites_url(self, url, size, expected):
+        """with_jpeg_size sets/appends JpegSize and no-ops on None."""
+        from custom_components.bosch_shc_camera.const import with_jpeg_size
+
+        assert with_jpeg_size(url, size) == expected
+
+
+class TestLocalSnapInlineBudget:
+    """The inline LOCAL snap budget must fit under HA's CAMERA_IMAGE_TIMEOUT
+    while still exceeding a Gen1 camera's cold cost.
+
+    The LOCAL branch returns straight after this attempt (it deliberately skips
+    the aiohttp fallback below it, which would only 401 without the Digest auth
+    just tried), so nothing else runs inside HA's 10 s ceiling. The previous
+    bare 6 s sat *below* these cameras' measured cold cost — TLS handshake
+    2.5-6.9 s, ~7.05 s end to end — and because a handshake killed by the
+    timeout is never pooled, such a camera never reaches the warm state where
+    6 s would have been enough. Regression guard for both ends of that range.
+    """
+
+    def test_budget_is_under_ha_camera_image_timeout(self):
+        from homeassistant.components.camera import CAMERA_IMAGE_TIMEOUT
+
+        from custom_components.bosch_shc_camera.camera import LOCAL_SNAP_TIMEOUT
+
+        assert LOCAL_SNAP_TIMEOUT < CAMERA_IMAGE_TIMEOUT, (
+            "an inline snap that outlives HA's timeout is cancelled mid-flight "
+            "and served to the card as a 500 body"
+        )
+
+    def test_budget_covers_a_cold_gen1_handshake(self):
+        from custom_components.bosch_shc_camera.camera import LOCAL_SNAP_TIMEOUT
+
+        assert LOCAL_SNAP_TIMEOUT >= 7.1, (
+            "a budget below the cold handshake+transfer cost can never succeed "
+            "from cold, and cold is the only state a timed-out camera reaches"
         )
 
 


### PR DESCRIPTION
Fixes the two root causes behind #55. Out of the four directions I listed there, these are the two that are minimal, generic and address the cause rather than the symptom — both running live on the reporting hardware (3× Gen1 Outdoor, mini-NVR, `stream_connection_type: local`). Fair warning on soak time: that's a few hours of observation, not weeks — the before/after numbers are solid and repeatable, but I can't claim long-run stability yet.

## What's wrong

Two independent things, both on the snapshot path.

**1. `snap.jpg` is always requested at full resolution.** Every call site hardcodes `JpegSize=1206`, including the ones that exist to fill a card tile — and the Lovelace card asks HA for `width=315`. Measured payloads, same frame, one Gen1 camera:

| `JpegSize` | payload |
|---|---|
| 1206 (hardcoded) | ~500 KB |
| 640 | ~220 KB |
| 320 | ~65 KB |

On a bandwidth-constrained link the full-res body alone can outlast HA's 10 s `CAMERA_IMAGE_TIMEOUT`, so the preview fetch fails outright and the card keeps showing whatever was cached.

**2. The inline LOCAL snap budget sits below what these cameras cost from cold.** `_async_camera_image_impl`'s tier-1 Digest fetch ran under `asyncio.timeout(6)`. The comment above it explains the 12 s → 6 s tightening as avoiding a `12 s + 10 s aiohttp fallback = >22 s` cascade — but on the **LOCAL** branch that cascade doesn't exist: the code returns immediately after this attempt and deliberately skips the aiohttp fallback below it (the comment two lines further down says why — the LOCAL `proxy_url` needs the Digest auth just attempted, so unauthenticated aiohttp would only 401). The only ceiling that actually applies here is HA's 10 s.

Measured on Gen1: the TLS handshake alone is 2.5–6.9 s (TCP connect underneath it is 10–500 ms), a cold end-to-end round-trip is ~7.05 s, and the same fetch warm on a pooled connection is 0.05–0.79 s — consistent with the curl table in #55 (4.34 s cold → 0.05–0.16 s over one reused connection).

That spread is the whole failure mode: **a budget above the warm cost but below the cold cost can never succeed from cold — and since a handshake killed by the timeout is never pooled, cold is the only state such a camera ever reaches.** That's why it failed 100 % of the time rather than occasionally.

Worth repeating from the thread: this is **NVR-mode**-specific, not camera-specific. A camera in `continuous` mode runs no pre-roll ring, so nothing covers for the snapshot path — it matters most exactly where there's no ring to hide it.

## What this PR changes

- **`const.py`** — `JPEG_SIZE_FULL/THUMB/MEDIUM` plus two small pure helpers: `jpeg_size_for_width()` (width → `JpegSize`, `None` meaning "keep full resolution") and `with_jpeg_size()` (set/append the query parameter).
- **`camera.py`** — derives `req_jpeg_size` once from the width HA passed to `async_camera_image()`, and applies it to the tier-1 live-proxy snap (LOCAL and REMOTE, plus the post-renewal retry) and the tier-2b outage snap. `asyncio.timeout(6)` → `LOCAL_SNAP_TIMEOUT = 8.5` (≈1.5 s margin under HA's ceiling), with the now-inaccurate rationale comment rewritten.
- **`coordinator.py`** — `async_fetch_live_snapshot` / `_async_fetch_live_snapshot_impl` / `async_fetch_live_snapshot_local` take `jpeg_size: int | None = None`.

**The archival paths are untouched.** The background image refresh, the `image.*` entity and the AI-analysis fetch pass no width, so `jpeg_size_for_width()` returns `None` and their URL is byte-for-byte what it was before. That was exactly my objection to pulling this lever in #56 — this is the version that doesn't degrade them.

## Before / after

Same camera (the weakest link of the three), Mini-NVR in `continuous` mode so no ring covers for it, same card request:

| | Result |
|---|---|
| **Before** | **6.0 s flat on every single request** (the timeout firing), byte-identical JPEG every time — a permanently frozen preview |
| **After** | **7.05 s cold, then 0.61–0.79 s** once pooled, different content every request. A frame fetched at **18:23:38** carried burnt-in OSD **18:23:37** — one second old |

Note the cold 7.05 s > 6 s: that first-open request could only ever fail under the old cap, and it now returns a *current* frame slowly instead of a stale one instantly.

## Deliberately not in this PR

Three more things are running locally and work well, but each is more invasive, more opinionated, or assumes the mini-NVR — I kept this PR to what I'd actually ship for everyone. Happy to submit any of them separately if you want them:

- **Mini-NVR ring frame extraction** — a pre-tier that decodes the freshest *closed* ring segment with `ffmpeg -sseof` (~0.1 s, ≤20 s old) while streaming. Excellent when it applies, but only helps `event_buffered` cameras and puts an ffmpeg subprocess on the snapshot path.
- **Out-of-band TLS warm-up** — on a LOCAL timeout, complete one Digest handshake as a background task with nothing awaiting it (rate-limited per camera), so later inline snaps land on a pooled connection; plus a periodic variant for ring-less LOCAL cameras that keeps both the pooled connection and the cached frame warm (that one took our cold-open from 7.05 s to ~0.01 s).
- **Serve-a-warm-cached-frame shortcut** — when the cached frame is younger than N seconds, return it immediately and kick the warm-up instead of paying the inline attempt. Opinionated about the freshness/latency trade-off, so it felt like your call, not mine.

An **adaptive** variant of change 2 is also reasonable — measure the handshake per camera and size the budget from it, since the cold/warm spread is huge but stable. I shipped the flat 8.5 s because it's one number a reviewer can check against a fixed 10 s ceiling; say the word and I'll do the adaptive version instead.

**#56** (the RCP `0x099e` probe starving `snap.jpg`) is a different file and mechanism and is deliberately not touched here.

## Tests / checks

Run locally on Python 3.14 against `requirements_test.txt`:

- `pytest tests/` — **6379 passed, 1 skipped** (`-n auto --dist=loadfile`, same invocation as CI).
- `mypy` (strict, per `pyproject.toml`) — **no issues in 59 source files**.
- `ruff check` + `ruff format --check` — clean.
- `codespell` — clean on the changed files.
- New in `tests/test_camera.py`: `TestSnapshotJpegSizeFromRequestedWidth` (the tier-1 LOCAL snap URL actually carries `JpegSize=320` for `width=315`, and is left untouched when no width is requested; parametrised coverage of the width→`JpegSize` mapping at both boundaries and of `with_jpeg_size`'s rewrite/append/no-op branches) and `TestLocalSnapInlineBudget` (the budget stays under HA's `CAMERA_IMAGE_TIMEOUT` and above the measured cold cost).
- 4 existing tier-2 assertions updated for the new keyword argument.
- `CHANGELOG.md` `[Unreleased]` entry added; commit signed off (DCO).
