### PR TITLE
Data on whether the LOCAL snap warm-up is redundant after #57 (re: beta-3)

### DIFF
--- a/custom_components/bosch_shc_camera/camera.py
+++ b/custom_components/bosch_shc_camera/camera.py
@@ -56,6 +56,8 @@ from .const import (
     JPEG_SIZE_FULL,
     JPEG_SIZE_MEDIUM,
     LIVE_SESSION_TTL,
+    LOCAL_SNAP_WARMUP_MIN_INTERVAL_SEC,
+    LOCAL_SNAP_WARMUP_TIMEOUT_SEC,
     STREAM_START_SKIPPED,
     TIMEOUT_SNAP,
     jpeg_size_for_width,
@@ -92,12 +94,17 @@ IDLE_FRAME_INTERVAL = (
 #
 # It used to be a bare 6 s, which is *below* what a Gen1 camera costs from
 # cold: the TLS handshake alone measures 2.5-6.9 s (the TCP connect under it is
-# 10-500 ms), and a cold snap.jpg round-trip measured 7.05 s end to end. A
-# budget above the warm cost but below the cold cost can never succeed from
-# cold — and since a handshake killed by the timeout is never pooled, cold is
-# the only state such a camera ever reaches, so it failed 100% of the time
-# rather than occasionally. Warm, over a pooled connection, the same fetch
-# takes 0.05-0.79 s.
+# 10-500 ms), and a cold snap.jpg round-trip measured 7.05 s end to end. Warm,
+# over a pooled connection, the same fetch takes 0.05-0.79 s.
+#
+# This complements _maybe_warm_local_snap_connection rather than replacing it.
+# The warm-up fixes requests 2..N — once a handshake completes, the pooled
+# connection puts every later fetch far inside any budget. But it can only be
+# scheduled *by* a failure, so the request that triggers it still returns the
+# stale cached frame; with a 6 s cap that first request could never do anything
+# else, since 6 s sits below the cold cost. Raising the cap lets the cold
+# request itself succeed, and a camera slower than 8.5 s still falls through to
+# the warm-up exactly as before.
 LOCAL_SNAP_TIMEOUT = 8.5
 
 # Worst-case cumulative time budget of the 5-tier snapshot fallback cascade in
@@ -204,6 +211,12 @@ class BoschCamera(CoordinatorEntity, Camera):  # type: ignore[misc]
         )  # monotonic timestamp of last *failed* fetch; separate so successes always update the cache window
         self._refresh_inflight: bool = False  # synchronous guard: set before first yield, cleared in finally  # prevents concurrent async_trigger_image_refresh (replaces locked()+async-with race)
         self._was_streaming: bool = False
+        # GitHub #55: background LOCAL-snap TLS warm-up (see
+        # _async_warm_local_snap_connection). Rate-limited via the timestamp;
+        # the task handle lets async_will_remove_from_hass cancel a pending
+        # attempt instead of leaking it past entity removal.
+        self._local_snap_warmup_task: asyncio.Task[None] | None = None
+        self._local_snap_warmup_last: float = float("-inf")  # SENTINEL_RULE
 
         info = coordinator.data.get(cam_id, {}).get("info", {})
         title = info.get("title", cam_id)
@@ -254,6 +267,13 @@ class BoschCamera(CoordinatorEntity, Camera):  # type: ignore[misc]
     async def async_will_remove_from_hass(self) -> None:
         """Called when entity is removed — unregister from coordinator."""
         self.coordinator.camera_entities.pop(self._cam_id, None)
+        # Best-effort — cancellation only lands at the warm-up task's next
+        # suspension point, so a task already past its last `await` (about to
+        # write cached_image/call async_write_ha_state synchronously) can
+        # still complete after this. Accepted: a state write to a
+        # soon-removed entity, not a crash.
+        if self._local_snap_warmup_task and not self._local_snap_warmup_task.done():
+            self._local_snap_warmup_task.cancel()
         await super().async_will_remove_from_hass()
 
     def _handle_coordinator_update(self) -> None:
@@ -1025,6 +1045,97 @@ class BoschCamera(CoordinatorEntity, Camera):  # type: ignore[misc]
             jpeg = await self.hass.async_add_executor_job(_rotate_jpeg_180, jpeg)
         return jpeg
 
+    def _maybe_warm_local_snap_connection(
+        self,
+        session: aiohttp.ClientSession,
+        proxy_url: str,
+        local_user: str,
+        local_pass: str,
+    ) -> None:
+        """Schedule a rate-limited background LOCAL-snap TLS warm-up.
+
+        GitHub #55: synchronous guard (set before any `await`) mirrors
+        `async_trigger_image_refresh`'s `_refresh_inflight` pattern — a second
+        concurrent caller within the same rate-limit window must not also
+        schedule a warm-up, which would double the concurrent-handshake load
+        on a camera already struggling to complete one.
+        """
+        now = time.monotonic()
+        if now - self._local_snap_warmup_last < LOCAL_SNAP_WARMUP_MIN_INTERVAL_SEC:
+            return
+        if self._local_snap_warmup_task and not self._local_snap_warmup_task.done():
+            return
+        self._local_snap_warmup_last = now
+        coro = self._async_warm_local_snap_connection(
+            session, proxy_url, local_user, local_pass
+        )
+        try:
+            # This is best-effort scheduling only — if hass rejects new
+            # background tasks (e.g. mid-shutdown), the caller (the LOCAL
+            # snap TimeoutError handler) must still fall through to its own
+            # cached_image/placeholder return, not propagate an exception
+            # from here and lose that fallback.
+            self._local_snap_warmup_task = self.hass.async_create_background_task(
+                coro, f"bosch_shc_camera_local_snap_warmup_{self._cam_id[:8]}"
+            )
+        except Exception as err:  # must never break the caller's own fallback
+            coro.close()
+            _LOGGER.debug(
+                "%s: could not schedule LOCAL snap warm-up: %s",
+                self._display_name,
+                err,
+            )
+
+    async def _async_warm_local_snap_connection(
+        self,
+        session: aiohttp.ClientSession,
+        proxy_url: str,
+        local_user: str,
+        local_pass: str,
+    ) -> None:
+        """Best-effort background Digest handshake to prime the connection pool.
+
+        GitHub #55: the inline LOCAL snap.jpg request is capped at 6s to stay
+        under HA's outer ``CAMERA_IMAGE_TIMEOUT`` — but on cameras whose TLS
+        handshake alone runs 2.5-6.9s, that cap kills the handshake before
+        aiohttp's connection pool ever gets a completed connection to reuse,
+        so every subsequent inline request starts cold and hits the same
+        wall. This runs on the same shared session (`auth_utils.async_digest_
+        request` calls `session.request()` directly, so a completed request
+        here pools a connection the next inline request to the same host can
+        reuse). On success this also opportunistically updates cached_image
+        with the frame it fetched, since the round trip already paid for it.
+        Silent no-op on any failure — the inline path already has its own
+        cached/placeholder fallback regardless of this task's outcome.
+        """
+        try:
+            async with asyncio.timeout(LOCAL_SNAP_WARMUP_TIMEOUT_SEC):
+                async with await async_digest_request(
+                    session,
+                    "GET",
+                    proxy_url,
+                    local_user,
+                    local_pass,
+                    timeout=LOCAL_SNAP_WARMUP_TIMEOUT_SEC,
+                    ssl=False,
+                ) as resp:
+                    if resp.status == 200 and "image" in resp.headers.get(
+                        "Content-Type", ""
+                    ):
+                        data = await resp.read()
+                        if data:
+                            self.cached_image = data
+                            self.last_image_fetch = time.monotonic()
+                            self.async_write_ha_state()
+                            _LOGGER.debug(
+                                "%s: LOCAL snap warm-up succeeded — %d bytes, "
+                                "connection now pooled for future requests",
+                                self._display_name,
+                                len(data),
+                            )
+        except (TimeoutError, aiohttp.ClientError, ValueError) as err:
+            _LOGGER.debug("%s: LOCAL snap warm-up failed: %s", self._display_name, err)
+
     async def _async_camera_image_impl(
         self, width: int | None = None, height: int | None = None
     ) -> bytes | None:
@@ -1161,11 +1272,11 @@ class BoschCamera(CoordinatorEntity, Camera):  # type: ignore[misc]
                         # Error" body rendered as a brown placeholder on the
                         # camera card. Nothing else runs after this attempt on
                         # the LOCAL branch (see the comment below the fetch), so
-                        # 8.5 s is the largest budget that still leaves margin
-                        # under HA's ceiling — and a Gen1 camera needs about
-                        # 7 s from cold. If it does fail, return
-                        # cached/placeholder immediately rather than racing HA's
-                        # outer timeout.
+                        # LOCAL_SNAP_TIMEOUT is sized to leave margin under HA's
+                        # ceiling while still covering a Gen1 camera's ~7 s cold
+                        # cost. If it does fail, the warm-up below is scheduled
+                        # and we return cached/placeholder immediately rather
+                        # than racing HA's outer timeout.
                         async with asyncio.timeout(LOCAL_SNAP_TIMEOUT):
                             async with await async_digest_request(
                                 session,
@@ -1185,6 +1296,15 @@ class BoschCamera(CoordinatorEntity, Camera):  # type: ignore[misc]
                         # from auth_utils.async_digest_request — forum 998974/15.
                         _LOGGER.debug("LOCAL snap via proxy failed: %s", err)
                         data = None
+                        if isinstance(err, TimeoutError):
+                            # GitHub #55: only a real timeout indicates the
+                            # "TLS handshake killed before completion" pattern
+                            # a warm-up can fix — a ValueError (malformed auth
+                            # header) or a connection-level ClientError won't
+                            # be helped by a slower retry of the same thing.
+                            self._maybe_warm_local_snap_connection(
+                                session, proxy_url, local_user, local_pass
+                            )
                     if data:
                         self.cached_image = data
                         self.last_image_fetch = time.monotonic()

--- a/custom_components/bosch_shc_camera/const.py
+++ b/custom_components/bosch_shc_camera/const.py
@@ -141,6 +141,16 @@ RCP_099E_PROBE_FAILURE_MEMO_SEC = (
     3600  # skip the probe for this long per-cam_id after a failure/timeout
 )
 
+# GitHub #55: LOCAL snap.jpg's inline Digest request is capped at 6s to stay
+# under HA's outer 10s CAMERA_IMAGE_TIMEOUT — too tight for cameras whose TLS
+# handshake alone runs 2.5-6.9s, and a handshake killed mid-flight never gets
+# pooled, so every request starts cold and hits the same wall. On a timeout,
+# a background attempt gets this much more generous budget to complete the
+# handshake once and leave a warm pooled connection for subsequent inline
+# requests, rate-limited so a persistently-slow camera isn't hammered.
+LOCAL_SNAP_WARMUP_TIMEOUT_SEC = 25.0
+LOCAL_SNAP_WARMUP_MIN_INTERVAL_SEC = 30.0
+
 # GET /v11/video_inputs (camera_list.py) — first call of every coordinator
 # tick, gating everything else that tick. A bare timeout here used to fail
 # the WHOLE tick immediately (community report, forum thread, 2026-07-23: a

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -601,6 +601,8 @@ def _make_camera(coord=None, entry=None, **camera_overrides):
     cam._refresh_inflight = (
         False  # synchronous in-flight guard (replaces _refresh_lock)
     )
+    cam._local_snap_warmup_task = None
+    cam._local_snap_warmup_last = float("-inf")
     cam._model = "HOME_Eyes_Outdoor"
     cam._model_name = "Eyes Outdoor"
     cam.hw_version = "HOME_Eyes_Outdoor"
@@ -739,6 +741,42 @@ class TestLifecycleHooks:
         ):
             await BoschCamera.async_will_remove_from_hass(cam)
         assert CAM_ID not in coord.camera_entities
+
+    @pytest.mark.asyncio
+    async def test_will_remove_cancels_pending_local_snap_warmup_task(self):
+        """GitHub #55: a still-pending background warm-up task must be
+        cancelled on entity removal, not left to run past it."""
+        from custom_components.bosch_shc_camera.camera import BoschCamera
+
+        coord = _make_coord()
+        cam = _make_camera(coord=coord)
+        pending_task = MagicMock()
+        pending_task.done.return_value = False
+        cam._local_snap_warmup_task = pending_task
+        with patch(
+            "custom_components.bosch_shc_camera.camera.CoordinatorEntity.async_will_remove_from_hass",
+            new=AsyncMock(),
+        ):
+            await BoschCamera.async_will_remove_from_hass(cam)
+        pending_task.cancel.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_will_remove_does_not_cancel_finished_warmup_task(self):
+        """An already-finished warm-up task must not be cancelled — nothing
+        to interrupt, and cancelling a done Task is harmless but pointless."""
+        from custom_components.bosch_shc_camera.camera import BoschCamera
+
+        coord = _make_coord()
+        cam = _make_camera(coord=coord)
+        finished_task = MagicMock()
+        finished_task.done.return_value = True
+        cam._local_snap_warmup_task = finished_task
+        with patch(
+            "custom_components.bosch_shc_camera.camera.CoordinatorEntity.async_will_remove_from_hass",
+            new=AsyncMock(),
+        ):
+            await BoschCamera.async_will_remove_from_hass(cam)
+        finished_task.cancel.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_will_remove_when_not_registered_no_crash(self):
@@ -2064,6 +2102,8 @@ def _make_camera_impl(coord=None, **camera_overrides):
     cam._force_image_refresh = False
     cam.last_image_fetch = 0.0
     cam._was_streaming = False
+    cam._local_snap_warmup_task = None
+    cam._local_snap_warmup_last = float("-inf")
     cam._model = "X"
     cam._model_name = "X"
     cam.hw_version = "X"
@@ -2072,6 +2112,9 @@ def _make_camera_impl(coord=None, **camera_overrides):
     cam.async_write_ha_state = MagicMock()
     cam.hass = SimpleNamespace(
         async_create_task=MagicMock(side_effect=lambda c: (c.close(), MagicMock())[1]),
+        async_create_background_task=MagicMock(
+            side_effect=lambda c, name: (c.close(), MagicMock())[1]
+        ),
         async_add_executor_job=AsyncMock(),
     )
     for k, v in camera_overrides.items():
@@ -2351,6 +2394,198 @@ class TestAsyncCameraImageImplLocalDigest:
             out = await BoschCamera._async_camera_image_impl(cam)
         digest_mock.assert_awaited_once()
         assert out == img
+
+
+class TestLocalSnapWarmup:
+    """GitHub #55: a real TimeoutError on the inline LOCAL Digest fetch
+    schedules a background warm-up (rate-limited), but a ValueError/
+    ClientError (not a timing issue) must not. Scheduling failures must
+    never break the caller's own cached/placeholder fallback."""
+
+    def _local_coord(self):
+        return _make_coord_impl(
+            live_connections={
+                CAM_ID: {
+                    "_connection_type": "LOCAL",
+                    "proxyUrl": "https://192.0.2.1/snap.jpg",
+                    "_local_user": "cbs-1",
+                    "_local_password": "p",
+                },
+            }
+        )
+
+    @pytest.mark.asyncio
+    async def test_timeout_schedules_warmup_task(self):
+        from custom_components.bosch_shc_camera.camera import BoschCamera
+
+        cam = _make_camera_impl(
+            coord=self._local_coord(), cached_image=b"\xff\xd8cached"
+        )
+        with (
+            patch(
+                "custom_components.bosch_shc_camera.camera.async_get_bosch_cloud_session",
+                new=AsyncMock(return_value=MagicMock()),
+            ),
+            patch(
+                "custom_components.bosch_shc_camera.camera.async_digest_request",
+                new=AsyncMock(side_effect=TimeoutError()),
+            ),
+        ):
+            out = await BoschCamera._async_camera_image_impl(cam)
+
+        assert out == b"\xff\xd8cached"
+        cam.hass.async_create_background_task.assert_called_once()
+        assert cam._local_snap_warmup_task is not None
+        assert cam._local_snap_warmup_last > float("-inf")
+
+    @pytest.mark.asyncio
+    async def test_client_error_does_not_schedule_warmup(self):
+        """A ClientError (not a timing issue) must not trigger a warm-up retry."""
+        import aiohttp
+
+        from custom_components.bosch_shc_camera.camera import BoschCamera
+
+        cam = _make_camera_impl(
+            coord=self._local_coord(), cached_image=b"\xff\xd8cached"
+        )
+        with (
+            patch(
+                "custom_components.bosch_shc_camera.camera.async_get_bosch_cloud_session",
+                new=AsyncMock(return_value=MagicMock()),
+            ),
+            patch(
+                "custom_components.bosch_shc_camera.camera.async_digest_request",
+                new=AsyncMock(side_effect=aiohttp.ClientError("network error")),
+            ),
+        ):
+            await BoschCamera._async_camera_image_impl(cam)
+
+        cam.hass.async_create_background_task.assert_not_called()
+        assert cam._local_snap_warmup_task is None
+
+    @pytest.mark.asyncio
+    async def test_second_timeout_within_rate_limit_skips_reschedule(self):
+        """A second timeout inside LOCAL_SNAP_WARMUP_MIN_INTERVAL_SEC must not
+        schedule a second concurrent warm-up attempt."""
+        from custom_components.bosch_shc_camera.camera import BoschCamera
+
+        cam = _make_camera_impl(
+            coord=self._local_coord(), cached_image=b"\xff\xd8cached"
+        )
+        with (
+            patch(
+                "custom_components.bosch_shc_camera.camera.async_get_bosch_cloud_session",
+                new=AsyncMock(return_value=MagicMock()),
+            ),
+            patch(
+                "custom_components.bosch_shc_camera.camera.async_digest_request",
+                new=AsyncMock(side_effect=TimeoutError()),
+            ),
+        ):
+            await BoschCamera._async_camera_image_impl(cam)
+            await BoschCamera._async_camera_image_impl(cam)
+
+        cam.hass.async_create_background_task.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_still_pending_task_skips_reschedule_even_past_rate_limit(self):
+        """A still-running warm-up task must block a reschedule even once the
+        rate-limit window itself has elapsed — two overlapping warm-ups would
+        double the concurrent-handshake load on an already-struggling camera."""
+        from custom_components.bosch_shc_camera.camera import BoschCamera
+
+        cam = _make_camera_impl(coord=self._local_coord())
+        cam._local_snap_warmup_last = time.monotonic() - 3600  # long past the limit
+        pending_task = MagicMock()
+        pending_task.done.return_value = False
+        cam._local_snap_warmup_task = pending_task
+
+        cam._maybe_warm_local_snap_connection(
+            MagicMock(), "https://192.0.2.1/snap.jpg", "cbs-1", "p"
+        )
+
+        cam.hass.async_create_background_task.assert_not_called()
+        assert cam._local_snap_warmup_task is pending_task
+
+    @pytest.mark.asyncio
+    async def test_scheduling_exception_does_not_break_fallback(self):
+        """If hass.async_create_background_task itself raises (e.g. during
+        shutdown), _async_camera_image_impl must still return its normal
+        cached/placeholder fallback, not propagate the scheduling error."""
+        from custom_components.bosch_shc_camera.camera import BoschCamera
+
+        cam = _make_camera_impl(
+            coord=self._local_coord(), cached_image=b"\xff\xd8cached"
+        )
+        cam.hass.async_create_background_task = MagicMock(
+            side_effect=RuntimeError("hass shutting down")
+        )
+        with (
+            patch(
+                "custom_components.bosch_shc_camera.camera.async_get_bosch_cloud_session",
+                new=AsyncMock(return_value=MagicMock()),
+            ),
+            patch(
+                "custom_components.bosch_shc_camera.camera.async_digest_request",
+                new=AsyncMock(side_effect=TimeoutError()),
+            ),
+        ):
+            out = await BoschCamera._async_camera_image_impl(cam)
+
+        assert out == b"\xff\xd8cached"
+        assert cam._local_snap_warmup_task is None
+
+    @pytest.mark.asyncio
+    async def test_warmup_coroutine_success_updates_cached_image(self):
+        """_async_warm_local_snap_connection itself, on a successful fetch,
+        updates cached_image and writes ha state."""
+        from custom_components.bosch_shc_camera.camera import BoschCamera
+
+        cam = _make_camera_impl(coord=self._local_coord())
+        img = b"\xff\xd8warmed"
+        cm = self._digest_resp_cm_helper(200, img, "image/jpeg")
+        with patch(
+            "custom_components.bosch_shc_camera.camera.async_digest_request",
+            new=AsyncMock(return_value=cm),
+        ):
+            await BoschCamera._async_warm_local_snap_connection(
+                cam, MagicMock(), "https://192.0.2.1/snap.jpg", "cbs-1", "p"
+            )
+
+        assert cam.cached_image == img
+        cam.async_write_ha_state.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_warmup_coroutine_timeout_is_silent(self):
+        """_async_warm_local_snap_connection swallows its own timeout —
+        it's best-effort, nothing depends on its result."""
+        from custom_components.bosch_shc_camera.camera import BoschCamera
+
+        cam = _make_camera_impl(
+            coord=self._local_coord(), cached_image=b"\xff\xd8untouched"
+        )
+        with patch(
+            "custom_components.bosch_shc_camera.camera.async_digest_request",
+            new=AsyncMock(side_effect=TimeoutError()),
+        ):
+            await BoschCamera._async_warm_local_snap_connection(
+                cam, MagicMock(), "https://192.0.2.1/snap.jpg", "cbs-1", "p"
+            )
+
+        assert cam.cached_image == b"\xff\xd8untouched"
+
+    @staticmethod
+    def _digest_resp_cm_helper(
+        status: int, body: bytes = b"", content_type: str = "image/jpeg"
+    ):
+        resp = MagicMock()
+        resp.status = status
+        resp.headers = {"Content-Type": content_type}
+        resp.read = AsyncMock(return_value=body)
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(return_value=resp)
+        cm.__aexit__ = AsyncMock(return_value=None)
+        return cm
 
 
 class TestPlaceholderTreatedAsNoCache:
@@ -4984,9 +5219,13 @@ class TestLocalSnapInlineBudget:
     the aiohttp fallback below it, which would only 401 without the Digest auth
     just tried), so nothing else runs inside HA's 10 s ceiling. The previous
     bare 6 s sat *below* these cameras' measured cold cost — TLS handshake
-    2.5-6.9 s, ~7.05 s end to end — and because a handshake killed by the
-    timeout is never pooled, such a camera never reaches the warm state where
-    6 s would have been enough. Regression guard for both ends of that range.
+    2.5-6.9 s, ~7.05 s end to end.
+
+    This is complementary to the background warm-up, which fixes requests 2..N
+    once a handshake has been banked: the warm-up can only be scheduled by a
+    failure, so the request that triggers it still serves the stale cached
+    frame, and under a 6 s cap the cold request could never do anything else.
+    Regression guard for both ends of the range.
     """
 
     def test_budget_is_under_ha_camera_image_timeout(self):


### PR DESCRIPTION
**Correction — I had this wrong when I opened it.** I assumed the warm-up had been dropped accidentally by my stale-based PR #57, and said so here. Your #55 comment makes clear it was deliberate: you judged it redundant once the direct budget fix covered the same case. That's a reasonable call and I shouldn't have framed it as an accident. Apologies.

So this is no longer "restore something lost" — it's "here's measured data suggesting it isn't redundant". If you read the numbers and still disagree, close it and I won't push further.

## The measurement

Stock v16.1.3-beta-3 on the reporting hardware (3× Gen1, mini-NVR, `stream_connection_type: local`), card-sized requests (`width=315`), 120 s apart so nothing is served from HA's `frame_interval` cache:

| | payload | latency |
|---|---|---|
| cam A | 46–47 KB | 5.23 / 8.51 / 5.75 / 5.38 s |
| cam B | 74–75 KB | 5.88 / 6.03 / 8.50 / 5.97 s |

**The sizing fix works exactly as intended** — payloads dropped ~7× (cam A 324–357 KB → 46 KB, cam B 519–545 KB → 74 KB) and frames are current every time.

**But latency didn't improve.** The 8.50/8.51 s entries are the new cap firing, not a fetch completing — 2 of 12 requests still time out. The rest complete, but at 5.2–6.0 s.

## Why I think that leaves the warm-up doing real work

The budget fix changed the outcome from *fail* to *succeed*, which is the important half. What it can't change is that every one of those requests is still paying a cold TLS handshake — 2.5–6.9 s measured on this hardware, which is the entire 5–6 s.

Over a **pooled** connection the same fetch is 0.05–0.79 s. The warm-up is the only thing that banks that pooled connection, because the inline path tears its socket down on timeout and never gets to reuse one.

So on this hardware the two aren't redundant, they're sequential: your budget fix makes the cold request succeed, and the warm-up makes every request *after* it fast. Without it, a user opening the dashboard waits ~5.5 s per tile indefinitely, rather than ~5.5 s once and then ~0.2 s.

I may still be wrong about your test rig — if your cameras handshake quickly, the warm-up genuinely buys nothing there and the added complexity isn't worth it for a case only slow-link installs hit. That's your call to make, and I'd understand either way.

## What's in the diff

Your beta-2 warm-up restored verbatim — the rate-limited scheduler with the synchronous guard, the `async_will_remove_from_hass` cancellation, firing only on a real `TimeoutError`, plus its test coverage — rebased onto beta-3 so #57's sizing and budget stay. `manifest.json` and `coordinator.py` untouched. Nothing of mine added.

`pytest tests/ -n auto --dist=loadfile` on Python 3.14: **6392 passed, 1 skipped**, including your warm-up tests.

## On #59

Fair catch, and it's a consequence of my PR making resolution intent explicit without carrying that intent into the probe. Happy to fix it — skipping the `0x099e` probe when `jpeg_size` is `None`/`JPEG_SIZE_FULL` — as a separate PR, unless you'd rather take it yourself.
